### PR TITLE
Add dummy default widgets before filtering on undefined object to prevent undefined exception

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -153,6 +153,16 @@ class App extends Component {
       configMap = metadata.config_map;
       widgetOrder = metadata.widget_order;
 
+      // Use default configMap if one isn't set up yet
+      if (configMap === undefined || configMap === null) {
+        ({ configMap } = DEFAULT_SETUP);
+      }
+
+      // Use default widgetOrder if one isn't set up yet
+      if (widgetOrder === undefined || widgetOrder === null) {
+        ({ widgetOrder } = DEFAULT_SETUP);
+      }
+
       // Remove widgets that no longer exist
       widgetOrder = widgetOrder.filter((widgetId) => {
         return idToWidget[widgetId];
@@ -161,16 +171,6 @@ class App extends Component {
       return this.setState({
         fatalErrorMessage: err.message,
       });
-    }
-
-    // Use default configMap if one isn't set up yet
-    if (configMap === undefined || configMap === null) {
-      ({ configMap } = DEFAULT_SETUP);
-    }
-
-    // Use default widgetOrder if one isn't set up yet
-    if (widgetOrder === undefined || widgetOrder === null) {
-      ({ widgetOrder } = DEFAULT_SETUP);
     }
 
     // Introduce student


### PR DESCRIPTION
The "widgetOrder = widgetOrder.filter" throws an undefined exception when the CourseDash is first installed in a course and has not widgets added yet.

Setting the widgets collection with a dummy set of default widgets prevents the undefined error.